### PR TITLE
Remove print debug statement

### DIFF
--- a/src/source.cpp
+++ b/src/source.cpp
@@ -135,7 +135,6 @@ void Source::fillBlock(unsigned int channels) {
 	if (this->is_lingering && this->generators.empty()) {
 		this->linger_countdown--;
 		if (this->linger_countdown == 0) {
-			printf("Hi");
 			this->signalLingerStopPoint();
 		}
 	}


### PR DESCRIPTION
Get rid of what's probably a debug print statement in src/source.cpp. I had to look through a good bit of code because this is something I might've done.

I have read CONTRIBUTING.md, am the sole contributor to this pull request, and license my contributions under the Unlicense.